### PR TITLE
endgame page display scores in double digits

### DIFF
--- a/src/main/java/gui/pages/EndGamePage.java
+++ b/src/main/java/gui/pages/EndGamePage.java
@@ -47,12 +47,12 @@ public class EndGamePage {
 
         // add label for player 1
         player1Label = new Label();
-        player1Label.createLabel(16, 10, 100, WIDTH / 4, 20, dialogueBox.frame, player1Name + "'s Score: " + player1Score, Color.BLACK);
+        player1Label.createLabel(16, 10, 100, WIDTH / 2, 20, dialogueBox.frame, player1Name + "'s Score: " + player1Score, Color.BLACK);
         player1Label.setCentreAlignment();
 
         // add label for player 2
         player2Label = new Label();
-        player2Label.createLabel(16, 10, 120, WIDTH / 4, 20, dialogueBox.frame, player2Name + "'s Score: " + player2Score, Color.BLACK);
+        player2Label.createLabel(16, 10, 120, WIDTH / 2, 20, dialogueBox.frame, player2Name + "'s Score: " + player2Score, Color.BLACK);
         player2Label.setCentreAlignment();
 
         winnerLabel = new Label();


### PR DESCRIPTION
# Description

Bug fix for if there is a larger sized player name and to make scores visible in double digits. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


- [ ] Tested via playing and loading games

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules